### PR TITLE
Update sentry to new version that supports Laravel 5.3 <

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,6 @@
     "homepage": "https://github.com/skydiver/october-plugin-sentryerrorlogger",
     "keywords": ["october", "cms", "sentry", "error", "logger"],
     "require": {
-        "sentry/sentry-laravel": "^0.7.0"
+        "sentry/sentry-laravel": "^0.8.0"
     }
 }


### PR DESCRIPTION
Fixes composer error on installs that are October Build 420 =< 

Fixes #2 