### PR TITLE
Updates with regard to October 2

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -25,7 +25,9 @@
 
         public function boot() {
 
-            $monolog = Log::getMonolog();
+            $isLaravel56OrUp = method_exists(\Illuminate\Log\Logger::class, 'getLogger');
+            $monolog = $isLaravel56OrUp ? Log::getLogger() : Log::getMonolog();
+
             $this->setSentryHandler($monolog);
 
             \Event::listen('backend.form.extendFields', function($widget) {

--- a/Plugin.php
+++ b/Plugin.php
@@ -1,6 +1,6 @@
 <?php
 
-    namespace Martin\SentryErrorLogger;
+    namespace KosmosKosmos\SentryErrorLogger;
 
     use System\Classes\PluginBase;
     use VojtaSvoboda\ErrorLogger\Models\Settings;

--- a/Plugin.php
+++ b/Plugin.php
@@ -1,6 +1,6 @@
 <?php
 
-    namespace KosmosKosmos\SentryErrorLogger;
+    namespace Martin\SentryErrorLogger;
 
     use System\Classes\PluginBase;
     use VojtaSvoboda\ErrorLogger\Models\Settings;

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,6 @@
     "homepage": "https://github.com/skydiver/october-plugin-sentryerrorlogger",
     "keywords": ["october", "cms", "sentry", "error", "logger"],
     "require": {
-        "sentry/sentry-laravel": "^0.9.2"
+        "sentry/sentry-laravel": "^2.5.3"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,8 @@
     "homepage": "https://github.com/skydiver/october-plugin-sentryerrorlogger",
     "keywords": ["october", "cms", "sentry", "error", "logger"],
     "require": {
-        "sentry/sentry-laravel": "^2.5.3"
+        "sentry/sentry-laravel": "^2.5.3",
+        "illuminate/contracts" : "6.20.*",
+        "illuminate/support" : "6.20.*"
     }
 }


### PR DESCRIPTION
Since October 2 uses Laravel 6.20 a call to a method that was renamed had to be updated. The solution is taken from similar update in the `VojtaSvoboda.ErrorLogger` Plugin this Plugin works with.
Also composer dependancies have been updated.